### PR TITLE
Fixed Remote Linter Issue

### DIFF
--- a/hamc-server-bedrock/config.yaml
+++ b/hamc-server-bedrock/config.yaml
@@ -7,7 +7,7 @@ arch:
   - amd64
   - aarch64
 ports:
-  19132/udp: "19132"
+  19132/udp: 19132
 ports_description:
   19132/udp: Minecraft Server Port
 options:


### PR DESCRIPTION
The remote Linter for Github Action HA Addons complains that the port must be a number and not a string.