### PR TITLE
Improve backup reliability

### DIFF
--- a/hamc-server-bedrock/CHANGELOG.md
+++ b/hamc-server-bedrock/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.2.0
+
+- Fixed native home assistant backups
+- BREAKING CHANGE: Server data now stored at addon_configs/<slug>\_hamc-bedrock
+
 ## 1.1.0
 
 - Fixed HAOS option loading

--- a/hamc-server-bedrock/CHANGELOG.md
+++ b/hamc-server-bedrock/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 1.2.0
 
 - Fixed native home assistant backups
-- BREAKING CHANGE: Server data now stored at addon_configs/<slug>\_hamc-bedrock
+- BREAKING CHANGE: Server data now stored at `/addon_configs/<slug>_hamc-bedrock`. The addon will attempt to migrate your data to the new location, but it is recommended to backup your `/addons/hamc-server-bedrock/data` folder before updating.
+
 
 ## 1.1.0
 

--- a/hamc-server-bedrock/Dockerfile
+++ b/hamc-server-bedrock/Dockerfile
@@ -53,7 +53,7 @@ ADD "https://raw.githubusercontent.com/alexbelgium/hassio-addons/master/.templat
 ADD "https://raw.githubusercontent.com/alexbelgium/hassio-addons/master/.templates/ha_entrypoint_modif.sh" "/ha_entrypoint_modif.sh"
 RUN chmod 777 /ha_entrypoint.sh /ha_entrypoint_modif.sh && /ha_entrypoint_modif.sh && rm /ha_entrypoint_modif.sh
 
-WORKDIR /addons/hamc-server-bedrock/data
+WORKDIR /config
 ENTRYPOINT [ "/usr/bin/env" ]
 CMD [ "/ha_entrypoint.sh" ]
 

--- a/hamc-server-bedrock/README.md
+++ b/hamc-server-bedrock/README.md
@@ -12,9 +12,9 @@ To access the Minecraft server from outside your network, forward port 19132 (UD
 <your_ip>:19132
 ```
 
-Server data is stored in the `/addons/hamc-server-bedrock/data` folder for easy backups & adjustments.
+Server data is stored in the `/addon_configs/<slug>_hamc-bedrock` folder for easy backups & adjustments.
 
 ## References
 
-* Thanks to [alexbelgium](https://github.com/alexbelgium/hassio-addons) for the add-on template.
-* Thanks to [itzg](https://github.com/itzg/docker-minecraft-bedrock-server) for the docker image.
+- Thanks to [alexbelgium](https://github.com/alexbelgium/hassio-addons) for the add-on template.
+- Thanks to [itzg](https://github.com/itzg/docker-minecraft-bedrock-server) for the docker image.

--- a/hamc-server-bedrock/config.yaml
+++ b/hamc-server-bedrock/config.yaml
@@ -1,6 +1,6 @@
 name: HAMC Server Bedrock
 description: Host a Bedrock Minecraft server on Home Assistant
-version: 1.1.0
+version: 1.2.0
 slug: hamc-bedrock
 init: false
 arch:

--- a/hamc-server-bedrock/config.yaml
+++ b/hamc-server-bedrock/config.yaml
@@ -70,6 +70,7 @@ schema:
   VISITORS: str
 map:
   - addons:rw
+  - addon_config:rw
 environment:
   EULA: "TRUE"
 

--- a/hamc-server-bedrock/config.yaml
+++ b/hamc-server-bedrock/config.yaml
@@ -68,6 +68,13 @@ schema:
   OPS: str
   MEMBERS: str
   VISITORS: str
+backup: cold
+backup_exclude:
+  - "bedrock_server*"
+  - "behavior_packs/vanilla*"
+  - "behavior_packs/chemistry*"
+  - "resource_packs/vanilla*"
+  - "resource_packs/chemistry*"
 map:
   - addons:rw
   - addon_config:rw

--- a/hamc-server-bedrock/rootfs/etc/cont-init.d/00-migrate_data.sh
+++ b/hamc-server-bedrock/rootfs/etc/cont-init.d/00-migrate_data.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bashio
+# shellcheck shell=bash
+
+if [ -d /addons/hamc-server-bedrock/data ]; then
+  if [ -z "$(ls -A /config)" ]; then
+    bashio::log.info "Migrating minecraft data from /addons to /addon_configs"
+    mv /addons/hamc-server-bedrock/data/* /config
+  else
+    bashio::log.warning "HAMC config files are present at both /addons/hamc-server-bedrock/data/ and /addon_configs/"
+    bashio::log.warning "Manual migration of minecraft data to /addon_configs/ may be required"
+  fi
+fi

--- a/hamc-server-bedrock/rootfs/etc/cont-init.d/00-migrate_data.sh
+++ b/hamc-server-bedrock/rootfs/etc/cont-init.d/00-migrate_data.sh
@@ -5,6 +5,7 @@ if [ -d /addons/hamc-server-bedrock/data ]; then
   if [ -z "$(ls -A /config)" ]; then
     bashio::log.info "Migrating minecraft data from /addons to /addon_configs"
     mv /addons/hamc-server-bedrock/data/* /config
+    rmdir /addons/hamc-server-bedrock/data /addons/hamc-server-bedrock
   else
     bashio::log.warning "HAMC config files are present at both /addons/hamc-server-bedrock/data/ and /addon_configs/"
     bashio::log.warning "Manual migration of minecraft data to /addon_configs/ may be required"


### PR DESCRIPTION
### Issue being addressed

The hamc-server-bedrock addon stores data under the `addons` folder.  Storing HAMC files in `addons` means the native homeassistant backup doesn't know to associate these files with HAMC. This means that backup functionality doesn't behave correctly:

- The user must remember to stop the `hamc-bedrock` add-on before performing backups otherwise the worlds database is likely to be corrupted.
- When performing partial backups, the user must remember to select both `addons` and `hamc-bedrock` to achieve complete HAMC backup.

This issue is discussed further at: https://developers.home-assistant.io/blog/2023/11/06/public-addon-config/

### Proposed change

This pull request migrates the HAMC-server-bedrock data to `addon-configs`.  Cold backups are then enforced through the addon configuration.  Backup sizes are reduced by excluding the bedrock-server executable and together with vanilla and chemistry resource_packs / behaviour_packs.

TODO: Note that backup sizes would be further reduced if the addon is installed from a repository image rather than built locally in home-assistant.