### PR TITLE
Fix send-command

### DIFF
--- a/hamc-server-bedrock/Dockerfile
+++ b/hamc-server-bedrock/Dockerfile
@@ -41,6 +41,9 @@ ENV PACKAGES=""
 ADD "https://raw.githubusercontent.com/alexbelgium/hassio-addons/master/.templates/ha_autoapps.sh" "/ha_autoapps.sh"
 RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
 
+# Fix send-command for server running in /config
+RUN sed -i 's~/data/bedrock_server-~/config/bedrock_server-~g' /usr/local/bin/send-command
+
 ################
 # 4 Entrypoint #
 ################


### PR DESCRIPTION
`/usr/local/bin/send-command` tries to find the server process by matching with path included, so this PR patches `send-command` to search for the process started from `/config` (instead of `/data` as in the source image).

Thanks for your work!